### PR TITLE
Fix Docker buildx cache configuration in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,12 @@ jobs:
             org.opencontainers.image.revision={{sha}}
             org.opencontainers.image.created={{created}}
       
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=moby/buildkit:v0.12.0
+      
       - name: Build and push Docker image (CPU)
         uses: docker/build-push-action@v5
         with:
@@ -53,6 +59,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
       
       - name: Build and push Docker image (GPU)
         uses: docker/build-push-action@v5
@@ -64,6 +71,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          platforms: linux/amd64
       
       - name: Generate Release Notes
         id: release_notes


### PR DESCRIPTION
## 🔧 Fix Docker Buildx Cache Issue

### Problem
Release workflow failed with error:


### Solution
- Added  to properly configure buildx
- Added platform specifications for multi-architecture builds
- Configured proper driver options for GitHub Actions cache

### Changes
- Added Docker buildx setup step with proper driver configuration
- Added platform support:  for CPU builds
- Added platform support:  for GPU builds

### Expected Result
- Release workflow should now complete successfully
- Docker images will be built with proper caching
- Multi-architecture support for better compatibility

---
**Type**: Bug Fix  
**Priority**: High (blocks releases)