### PR TITLE
fix(ci): handle bad object error in change detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,13 @@ jobs:
             # PRの場合
             CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
           else
-            # Pushの場合
-            CHANGED_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }})
+            # Pushの場合 - より安全な方法
+            if [ -n "${{ github.event.before }}" ] && [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
+              CHANGED_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }})
+            else
+              # 初回プッシュや履歴が不完全な場合
+              CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || git ls-files)
+            fi
           fi
           
           echo "Changed files:"


### PR DESCRIPTION
Fix CI pipeline failure caused by bad object reference.

## Problem
- CI was failing with 'fatal: bad object' error
- This occurred when trying to diff between non-existent commit hashes
- Happened after force-pushing dev branch

## Solution
- Added safety checks for github.event.before
- Handle cases where commit history is incomplete
- Fallback to HEAD~1 or git ls-files when needed

## Changes
- Enhanced change detection logic in quick-check job
- Added null/zero hash checks
- Improved error handling for edge cases

This should resolve the CI pipeline failures.