### PR TITLE
fix(ci): handle force push and missing commit hashes in change detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,14 @@ jobs:
           else
             # Pushの場合 - より安全な方法
             if [ -n "${{ github.event.before }}" ] && [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
-              CHANGED_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }})
+              # コミットハッシュの存在確認
+              if git rev-parse --verify "${{ github.event.before }}" >/dev/null 2>&1; then
+                CHANGED_FILES=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }})
+              else
+                # コミットが存在しない場合（force push等）
+                echo "Warning: Previous commit ${{ github.event.before }} not found, checking all files"
+                CHANGED_FILES=$(git ls-files)
+              fi
             else
               # 初回プッシュや履歴が不完全な場合
               CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || git ls-files)


### PR DESCRIPTION
## 修正内容

CIパイプラインの変更検出ロジックを改善し、force pushや存在しないコミットハッシュのエラーを回避します。

### 変更点
- コミットハッシュの存在確認を追加
- force push時のフォールバック処理を実装
- より安全な変更検出ロジックに修正

### 問題
- devブランチのforce push後、CIがエラーで失敗
- 古いコミットハッシュ（594f832）を参照していた

### 解決方法
- でコミットの存在確認
- 存在しない場合は全ファイルをチェック対象に

これでdevブランチのCIパイプラインが正常に動作します。