### PR TITLE
feat(ci): add automatic dev branch sync with main

### DIFF
--- a/.github/workflows/sync-dev.yml
+++ b/.github/workflows/sync-dev.yml
@@ -1,0 +1,36 @@
+name: Sync dev branch with main
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  sync-dev:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Configure Git
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+      
+      - name: Sync dev branch with main
+        run: |
+          # devブランチをmainに同期
+          git checkout dev || git checkout -b dev
+          git reset --hard main
+          git push origin dev --force
+          
+          echo "✅ dev branch synchronized with main"
+      
+      - name: Create sync notification
+        run: |
+          echo "🔄 Dev branch has been automatically synchronized with main"
+          echo "📅 Sync time: $(date)"
+          echo "🔗 Main commit: $(git rev-parse --short HEAD)" 


### PR DESCRIPTION
## 新機能: 自動devブランチ同期

mainブランチにマージされた後に、自動でdevブランチを同期するGitHub Actionを追加しました。

### 🚀 追加機能
- **自動同期ワークフロー**: 
- **トリガー**: mainブランチへのプッシュ
- **動作**: devブランチをmainに強制同期

### 🔄 改善されたブランチ戦略


### ✅ 解決される問題
- devブランチの分岐問題
- マージコンフリクトのリスク軽減
- ブランチ管理の自動化

### 📋 変更内容
1. CIパイプラインの変更検出ロジック改善
2. 自動devブランチ同期ワークフロー追加
3. ブランチ戦略の最適化

これで、mainマージ後にdevブランチが自動的に同期され、常に最新の状態が保たれます。