### PR TITLE
fix(ci): add permissions for github-actions to push to dev branch

### DIFF
--- a/.github/workflows/sync-dev.yml
+++ b/.github/workflows/sync-dev.yml
@@ -33,4 +33,7 @@ jobs:
         run: |
           echo "🔄 Dev branch has been automatically synchronized with main"
           echo "📅 Sync time: $(date)"
-          echo "🔗 Main commit: $(git rev-parse --short HEAD)" 
+          echo "🔗 Main commit: $(git rev-parse --short HEAD)"
+
+permissions:
+  contents: write 


### PR DESCRIPTION
## 修正内容

github-actionsがdevブランチへpushできるよう、sync-dev.ymlにpermissions: contents: writeを追加しました。

- devブランチの自動同期ワークフローが403エラーで失敗していた問題を修正
- mainマージ後の自動同期が正常に動作するようになります

ご確認よろしくお願いします。