### PR TITLE
最新ブランチ PR候補

### DIFF
--- a/merlai/api/routes.py
+++ b/merlai/api/routes.py
@@ -112,6 +112,7 @@ async def generate_music(
             )
         # Generate MIDI data
         midi_data = midi_generator.merge_tracks(tracks)
+        duration = _calculate_tracks_duration(tracks)
         # Extract harmony chords for response
         try:
             midi_str = (
@@ -122,7 +123,7 @@ async def generate_music(
                 bass_line=bass_line.notes if bass_line is not None else None,
                 drums=drums.notes if drums is not None else None,
                 midi_data=midi_str,
-                duration=4.0,  # TODO: Calculate actual duration
+                duration=duration,
                 success=True,
             )
         except Exception:
@@ -616,3 +617,14 @@ def _chord_to_notes(chord: Chord) -> List[Note]:
             )
             notes.append(note)
     return notes
+
+
+def _calculate_tracks_duration(tracks: List[Track]) -> float:
+    """Calculate the duration (in seconds) from the latest note end time."""
+    max_end = 0.0
+    for track in tracks:
+        for note in track.notes:
+            note_end = note.start_time + note.duration
+            if note_end > max_end:
+                max_end = note_end
+    return max_end


### PR DESCRIPTION
Calculate generated music `duration` from tracks instead of a fixed value.

---
<a href="https://cursor.com/background-agent?bcId=bc-fbf26737-02e6-42d5-aa95-66aee2b8e5a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fbf26737-02e6-42d5-aa95-66aee2b8e5a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Computes and returns accurate generated music duration based on track contents.
> 
> - Adds `_calculate_tracks_duration` to derive duration from the latest note end across all `Track`s
> - Uses computed `duration` in `GenerationResponse` instead of the previous fixed value
> - MIDI track merging and payload structure otherwise unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1371b3d56b1faacf065cfd53056dfe0d567b74ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->